### PR TITLE
Create Merchant Relationship Endpoints

### DIFF
--- a/app/controllers/api/v1/merchants/invoices_controller.rb
+++ b/app/controllers/api/v1/merchants/invoices_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::Merchants::InvoicesController < ApplicationController
   def index
-    invoices = Merchant.find(params[:merchant_id]).invoices
+    invoices = Merchant.find(params[:merchant_id]).invoices.order(:id)
     render json: InvoiceSerializer.new(invoices)
   end
 end

--- a/app/controllers/api/v1/merchants/invoices_controller.rb
+++ b/app/controllers/api/v1/merchants/invoices_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Merchants::InvoicesController < ApplicationController
+  def index
+    invoices = Merchant.find(params[:merchant_id]).invoices
+    render json: InvoiceSerializer.new(invoices)
+  end
+end

--- a/app/controllers/api/v1/merchants/items_controller.rb
+++ b/app/controllers/api/v1/merchants/items_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Merchants::ItemsController < ApplicationController
+  def index
+    render json: ItemSerializer.new(Merchant.find(params[:merchant_id]).items)
+  end
+end

--- a/app/controllers/api/v1/merchants/items_controller.rb
+++ b/app/controllers/api/v1/merchants/items_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Merchants::ItemsController < ApplicationController
   def index
-    render json: ItemSerializer.new(Merchant.find(params[:merchant_id]).items)
+    items = Merchant.find(params[:merchant_id]).items
+    render json: ItemSerializer.new(items)
   end
 end

--- a/app/controllers/api/v1/merchants/items_controller.rb
+++ b/app/controllers/api/v1/merchants/items_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::Merchants::ItemsController < ApplicationController
   def index
-    items = Merchant.find(params[:merchant_id]).items
+    items = Merchant.find(params[:merchant_id]).items.order(:id)
     render json: ItemSerializer.new(items)
   end
 end

--- a/app/serializers/invoice_serializer.rb
+++ b/app/serializers/invoice_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# FastJsonapi Serializer for Invoice model
+class InvoiceSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :status, :customer_id, :merchant_id
+end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# FastJsonapi Serializer for Item model
+class ItemSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :name, :description, :unit_price, :merchant_id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
         get '/random', to: 'random#show'
         get '/:id', to: 'merchants#show'
         get '/:merchant_id/items', to: 'items#index'
+        get '/:merchant_id/invoices', to: 'invoices#index'
       end
 
       namespace :customers do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
         get '/find', to: 'find#show'
         get '/random', to: 'random#show'
         get '/:id', to: 'merchants#show'
+        get '/:merchant_id/items', to: 'items#index'
       end
 
       namespace :customers do

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :invoice do
     status { 'MyText' }
-    customer { nil }
+    customer
     merchant { nil }
   end
 end

--- a/spec/requests/api/v1/merchants/invoices/index_spec.rb
+++ b/spec/requests/api/v1/merchants/invoices/index_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'As a visitor', type: :request do
+  describe 'when I send a get request to the "merchant/:id/invoices" path' do
+    before(:each) do
+      @merchant_1 = create(:merchant)
+      @merchant_2 = create(:merchant)
+      @invoice_1 = create(:invoice, merchant: @merchant_1)
+      @invoice_2 = create(:invoice, merchant: @merchant_1)
+      @invoice_3 = create(:invoice, merchant: @merchant_1)
+      @invoice_4 = create(:invoice, merchant: @merchant_2)
+      @invoice_5 = create(:invoice, merchant: @merchant_2)
+
+      @invoices = [@invoice_1, @invoice_2, @invoice_3]
+
+      get "/api/v1/merchants/#{@merchant_1.id}/invoices"
+      @hash = JSON.parse(response.body)
+    end
+
+    it 'I get a JSON:API response with all invoices associated with merchant' do
+      expect(@hash.class).to eq(Hash)
+      expect(@hash.keys).to eq(['data'])
+      expect(@hash['data'].length).to eq(3)
+
+      invoices = @hash['data']
+      invoices.each_with_index do |invoice, index|
+        expect(invoice['id']).to eq(@invoices[index].id.to_s)
+        expect(invoice['type']).to eq('invoice')
+
+        attributes = invoice['attributes']
+
+        expect(attributes['id']).to eq(@invoices[index].id)
+        expect(attributes['customer_id']).to eq(@invoices[index].customer_id)
+        expect(attributes['status']).to eq(@invoices[index].status)
+        expect(attributes['merchant_id']).to eq(@invoices[index].merchant_id)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/merchants/items/index_spec.rb
+++ b/spec/requests/api/v1/merchants/items/index_spec.rb
@@ -32,8 +32,6 @@ RSpec.describe 'As a visitor', type: :request do
         expect(attributes['name']).to eq(@items[index].name)
         expect(attributes['description']).to eq(@items[index].description)
         expect(attributes['unit_price']).to eq(@items[index].unit_price)
-        expect(attributes['created_at']).to eq(@items[index].created_at)
-        expect(attributes['updated_at']).to eq(@items[index].updated_at)
         expect(attributes['merchant_id']).to eq(@items[index].merchant_id)
       end
     end

--- a/spec/requests/api/v1/merchants/items/index_spec.rb
+++ b/spec/requests/api/v1/merchants/items/index_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'As a visitor', type: :request do
+  describe 'when I send a get request to the "merchant/:id/items" path' do
+    before(:each) do
+      @merchant_1 = create(:merchant)
+      @merchant_2 = create(:merchant)
+      @item_1 = create(:item, merchant: @merchant_1)
+      @item_2 = create(:item, merchant: @merchant_1)
+      @item_3 = create(:item, merchant: @merchant_1)
+      @item_4 = create(:item, merchant: @merchant_2)
+      @item_5 = create(:item, merchant: @merchant_2)
+
+      @items = [@item_1, @item_2, @item_3]
+
+      get "/api/v1/merchants/#{@merchant_1.id}/items"
+      @hash = JSON.parse(response.body)
+    end
+
+    it 'I get a JSON:API response with all items associated with merchant' do
+      expect(@hash.class).to eq(Hash)
+      expect(@hash.keys).to eq(['data'])
+      expect(@hash['data'].length).to eq(3)
+
+      items = @hash['data']
+      items.each_with_index do |item, index|
+        expect(item['id']).to eq(@items[index].id.to_s)
+        expect(item['type']).to eq('item')
+
+        attributes = item['attributes']
+
+        expect(attributes['name']).to eq(@items[index].name)
+        expect(attributes['description']).to eq(@items[index].description)
+        expect(attributes['unit_price']).to eq(@items[index].unit_price)
+        expect(attributes['created_at']).to eq(@items[index].created_at)
+        expect(attributes['updated_at']).to eq(@items[index].updated_at)
+        expect(attributes['merchant_id']).to eq(@items[index].merchant_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Created merchant relationship endpoints `/items` and `/invoices`. 
Resolves #33, resolves #34.

Spec harness results:
```
MerchantsApiTest#test_loads_a_collection_of_invoices_associated_with_one_merchant = 0.15 s = .
MerchantsApiTest#test_loads_a_collection_of_items_associated_with_one_merchant = 0.03 s = .

Finished in 0.190823s, 10.4809 runs/s, 995.6871 assertions/s.
2 runs, 190 assertions, 0 failures, 0 errors, 0 skips
```

Test results:
```
Finished in 0.66513 seconds (files took 1.83 seconds to load)
55 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/turing/3module/projects/rale
s_engine/coverage. 955 / 955 LOC (100.0%) covered.
```