### PR TITLE
Create Item Record Endpoints

### DIFF
--- a/app/controllers/api/v1/items/find_controller.rb
+++ b/app/controllers/api/v1/items/find_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Controller for Find Single Item Endpoint
+class Api::V1::Items::FindController < ApplicationController
+  def show
+    render json: ItemSerializer.new(found_records(:ci_find, :find_by))
+  end
+
+  def index
+    render json: ItemSerializer.new(found_records(:ci_find_all, :where))
+  end
+
+  private
+
+  def parameters
+    params.permit(:name,
+                  :description,
+                  :id,
+                  :created_at,
+                  :updated_at,
+                  :merchant_id,
+                  :unit_price)
+  end
+
+  def attribute
+    parameters.keys.first
+  end
+
+  def value
+    parameters.values.first
+  end
+
+  def found_records(name_method, other_method)
+    if ["name", "description"].include?(attribute)
+      Item.send(name_method, attribute, value)
+    elsif attribute == 'unit_price'
+      formatted_value = value.delete('.').to_i
+      Item.send(other_method, attribute => formatted_value)
+    else
+      Item.send(other_method, attribute => value)
+    end
+  end
+end

--- a/app/controllers/api/v1/items/items_controller.rb
+++ b/app/controllers/api/v1/items/items_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Items::ItemsController < ApplicationController
+  def show    
+    render json: ItemSerializer.new(Item.find(params[:id]))
+  end
+end

--- a/app/controllers/api/v1/items/items_controller.rb
+++ b/app/controllers/api/v1/items/items_controller.rb
@@ -1,5 +1,9 @@
 class Api::V1::Items::ItemsController < ApplicationController
-  def show    
+  def show
     render json: ItemSerializer.new(Item.find(params[:id]))
+  end
+
+  def index
+    render json: ItemSerializer.new(Item.all)
   end
 end

--- a/app/controllers/api/v1/items/random_controller.rb
+++ b/app/controllers/api/v1/items/random_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Items::RandomController < ApplicationController
+  def show
+    render json: ItemSerializer.new(Item.random)
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,6 +8,10 @@ class Item < ApplicationRecord
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
 
+  def unit_price_decimal
+    unit_price / 100.0
+  end
+
   def self.best_day(item_id)
     joins(invoices: :transactions)
       .select("date_trunc('day', invoices.created_at) AS date")

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -3,5 +3,9 @@
 # FastJsonapi Serializer for Item model
 class ItemSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :id, :name, :description, :unit_price, :merchant_id
+  attributes :id, :name, :description, :merchant_id
+
+  attribute :unit_price do |object|
+    sprintf('%.2f', object.unit_price / 100.0)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
         get '/', to: 'items#index'
         get '/most_revenue', to: 'most_revenue#index'
         get '/find', to: 'find#show'
+        get '/find_all', to: 'find#index'
         get '/:id', to: 'items#show'
         get '/:id/best_day', to: 'best_day#show'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
 
       namespace :items do
         get '/most_revenue', to: 'most_revenue#index'
+        get '/:id', to: 'items#show'
         get '/:id/best_day', to: 'best_day#show'
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
         get '/most_revenue', to: 'most_revenue#index'
         get '/find', to: 'find#show'
         get '/find_all', to: 'find#index'
+        get '/random', to: 'random#show'
         get '/:id', to: 'items#show'
         get '/:id/best_day', to: 'best_day#show'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       end
 
       namespace :items do
+        get '/', to: 'items#index'
         get '/most_revenue', to: 'most_revenue#index'
         get '/:id', to: 'items#show'
         get '/:id/best_day', to: 'best_day#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
       namespace :items do
         get '/', to: 'items#index'
         get '/most_revenue', to: 'most_revenue#index'
+        get '/find', to: 'find#show'
         get '/:id', to: 'items#show'
         get '/:id/best_day', to: 'best_day#show'
       end

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -35,5 +35,11 @@ RSpec.describe ApplicationRecord, type: :model do
         expect(found_records_3).to eq([@customer_4])
       end
     end
+
+    describe 'random' do
+      it 'returns a random record in model' do
+        expect(Customer.random).to be_instance_of(Customer)
+      end
+    end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe Item, type: :model do
   end
 
   describe 'methods' do
+    describe 'instance methods' do
+      describe 'unit_price_decimal' do
+        it 'returns unit_price as float with two decimal places' do
+          @merchant = create(:merchant)
+          @item = create(:item, unit_price: 12345, merchant: @merchant)
+
+          expect(@item.unit_price_decimal).to eq(123.45)
+        end
+      end
+    end
+
     describe 'class methods' do
       describe 'best_day' do
         it 'returns date in YYYY-MM-DD format of date item had most revenue' do

--- a/spec/requests/api/v1/customers/find/index_spec.rb
+++ b/spec/requests/api/v1/customers/find/index_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe 'As a visitor', type: :request do
   before(:each) do
     # Create enough test data to have 1-2 records match each search parameter
+    @c_3 = create(:customer, first_name: 'Daniel', last_name: 'Frampton')
+    @c_5 = create(:customer, last_name: 'Frampton')
+    @c_7 = create(:customer, first_name: 'Daniel')
     @c_1 = create(:customer, created_at: Time.zone.parse('2020-01-01'))
     @c_2 = create(:customer, updated_at: Time.zone.parse('2020-01-02'))
-    @c_3 = create(:customer, first_name: 'Daniel', last_name: 'Frampton')
     @c_4 = create(:customer, created_at: Time.zone.parse('2020-01-01'))
-    @c_5 = create(:customer, last_name: 'Frampton')
     @c_6 = create(:customer) # Candidate for search by ID
-    @c_7 = create(:customer, first_name: 'Daniel')
     @c_8 = create(:customer, updated_at: Time.zone.parse('2020-01-02'))
 
     # Provide plural name of resource being requested; interpolated below.

--- a/spec/requests/api/v1/items/find/index_spec.rb
+++ b/spec/requests/api/v1/items/find/index_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'As a visitor', type: :request do
         expect(@json.class).to eq(Hash)
         expect(@json.keys).to eq(['data'])
         expect(@json['data'].class).to eq(Array)
-        expect(@json['data'].length).to eq(2)
+        expect(@json['data'].length).to eq(1)
 
         expected = [@item_1]
         @json['data'].each_with_index do |item, index|
@@ -91,7 +91,7 @@ RSpec.describe 'As a visitor', type: :request do
         expect(@json['data'].class).to eq(Array)
         expect(@json['data'].length).to eq(2)
 
-        expected = [@item_5, @item_10]
+        expected = [@item_5, @item_11]
         @json['data'].each_with_index do |item, index|
           expect(item['id']).to eq(expected[index].id.to_s)
           expect(item['type']).to eq('item')

--- a/spec/requests/api/v1/items/find/index_spec.rb
+++ b/spec/requests/api/v1/items/find/index_spec.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'As a visitor', type: :request do
+  before(:each) do
+    @merchant = create(:merchant)
+    @item_1 = create(:item, merchant: @merchant)
+    @item_2 = create(:item, merchant: @merchant, name: 'Test Item')
+    @item_8 = create(:item, merchant: @merchant, name: 'Test Item')
+    @item_3 = create(:item, merchant: @merchant, description: 'Bad Item')
+    @item_9 = create(:item, merchant: @merchant, description: 'Bad Item')
+    @item_4 = create(:item, merchant: @merchant, unit_price: '12345')
+    @item_10 = create(:item, merchant: @merchant, unit_price: '12345')
+    @item_5 = create(:item, merchant: @merchant, created_at: '1985-10-22')
+    @item_11 = create(:item, merchant: @merchant, created_at: '1985-10-22')
+    @item_6 = create(:item, merchant: @merchant, updated_at: '2008-09-08')
+    @item_12 = create(:item, merchant: @merchant, updated_at: '2008-09-08')
+    @merchant_2 = create(:merchant)
+    @item_7 = create(:item, merchant: @merchant_2)
+    @item_13 = create(:item, merchant: @merchant_2)
+  end
+
+  describe 'when I send a get request to the items find_all path' do
+    describe 'by their name attribute case-insensitive' do
+      before(:each) do
+        get "/api/v1/items/find_all?name=#{@item_2.name.downcase}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response with attributes of all found items' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.keys).to eq(['data'])
+        expect(@json['data'].class).to eq(Array)
+        expect(@json['data'].length).to eq(2)
+
+        expected = [@item_2, @item_8]
+        @json['data'].each_with_index do |item, index|
+          expect(item['id']).to eq(expected[index].id.to_s)
+          expect(item['type']).to eq('item')
+
+          attributes = item['attributes']
+          formatted_price = sprintf('%.2f', expected[index].unit_price / 100.0)
+
+          expect(attributes['name']).to eq(expected[index].name)
+          expect(attributes['description']).to eq(expected[index].description)
+          expect(attributes['unit_price']).to eq(formatted_price)
+          expect(attributes['merchant_id']).to eq(expected[index].merchant_id)
+        end
+      end
+    end
+
+    describe 'by their id attribute' do
+      before(:each) do
+        get "/api/v1/items/find_all?id=#{@item_1.id}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response with attributes of all found items' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.keys).to eq(['data'])
+        expect(@json['data'].class).to eq(Array)
+        expect(@json['data'].length).to eq(2)
+
+        expected = [@item_1]
+        @json['data'].each_with_index do |item, index|
+          expect(item['id']).to eq(expected[index].id.to_s)
+          expect(item['type']).to eq('item')
+
+          attributes = item['attributes']
+          formatted_price = sprintf('%.2f', expected[index].unit_price / 100.0)
+
+          expect(attributes['name']).to eq(expected[index].name)
+          expect(attributes['description']).to eq(expected[index].description)
+          expect(attributes['unit_price']).to eq(formatted_price)
+          expect(attributes['merchant_id']).to eq(expected[index].merchant_id)
+        end
+
+      end
+    end
+
+    describe 'by their created_at attribute' do
+      before(:each) do
+        get "/api/v1/items/find_all?created_at=#{@item_5.created_at}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response with attributes of all found items' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.keys).to eq(['data'])
+        expect(@json['data'].class).to eq(Array)
+        expect(@json['data'].length).to eq(2)
+
+        expected = [@item_5, @item_10]
+        @json['data'].each_with_index do |item, index|
+          expect(item['id']).to eq(expected[index].id.to_s)
+          expect(item['type']).to eq('item')
+
+          attributes = item['attributes']
+          formatted_price = sprintf('%.2f', expected[index].unit_price / 100.0)
+
+          expect(attributes['name']).to eq(expected[index].name)
+          expect(attributes['description']).to eq(expected[index].description)
+          expect(attributes['unit_price']).to eq(formatted_price)
+          expect(attributes['merchant_id']).to eq(expected[index].merchant_id)
+        end
+
+      end
+    end
+
+    describe 'by their updated_at attribute' do
+      before(:each) do
+        get "/api/v1/items/find_all?updated_at=#{@item_6.updated_at}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response with attributes of all found items' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.keys).to eq(['data'])
+        expect(@json['data'].class).to eq(Array)
+        expect(@json['data'].length).to eq(2)
+
+        expected = [@item_6, @item_12]
+        @json['data'].each_with_index do |item, index|
+          expect(item['id']).to eq(expected[index].id.to_s)
+          expect(item['type']).to eq('item')
+
+          attributes = item['attributes']
+          formatted_price = sprintf('%.2f', expected[index].unit_price / 100.0)
+
+          expect(attributes['name']).to eq(expected[index].name)
+          expect(attributes['description']).to eq(expected[index].description)
+          expect(attributes['unit_price']).to eq(formatted_price)
+          expect(attributes['merchant_id']).to eq(expected[index].merchant_id)
+        end
+
+      end
+    end
+
+    describe 'by their description attribute' do
+      before(:each) do
+        get "/api/v1/items/find_all?description=#{@item_3.description}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response with attributes of all found items' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.keys).to eq(['data'])
+        expect(@json['data'].class).to eq(Array)
+        expect(@json['data'].length).to eq(2)
+
+        expected = [@item_3, @item_9]
+        @json['data'].each_with_index do |item, index|
+          expect(item['id']).to eq(expected[index].id.to_s)
+          expect(item['type']).to eq('item')
+
+          attributes = item['attributes']
+          formatted_price = sprintf('%.2f', expected[index].unit_price / 100.0)
+
+          expect(attributes['name']).to eq(expected[index].name)
+          expect(attributes['description']).to eq(expected[index].description)
+          expect(attributes['unit_price']).to eq(formatted_price)
+          expect(attributes['merchant_id']).to eq(expected[index].merchant_id)
+        end
+
+      end
+    end
+
+    describe 'by their merchant_id attribute' do
+      before(:each) do
+        get "/api/v1/items/find_all?merchant_id=#{@item_7.merchant_id}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response with attributes of all found items' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.keys).to eq(['data'])
+        expect(@json['data'].class).to eq(Array)
+        expect(@json['data'].length).to eq(2)
+
+        expected = [@item_7, @item_13]
+        @json['data'].each_with_index do |item, index|
+          expect(item['id']).to eq(expected[index].id.to_s)
+          expect(item['type']).to eq('item')
+
+          attributes = item['attributes']
+          formatted_price = sprintf('%.2f', expected[index].unit_price / 100.0)
+
+          expect(attributes['name']).to eq(expected[index].name)
+          expect(attributes['description']).to eq(expected[index].description)
+          expect(attributes['unit_price']).to eq(formatted_price)
+          expect(attributes['merchant_id']).to eq(expected[index].merchant_id)
+        end
+
+      end
+    end
+
+    describe 'by their unit_price attribute' do
+      before(:each) do
+        formatted_price = sprintf('%.2f', @item_4.unit_price / 100.0)
+        get "/api/v1/items/find_all?unit_price=#{formatted_price}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response with attributes of all found items' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.keys).to eq(['data'])
+        expect(@json['data'].class).to eq(Array)
+        expect(@json['data'].length).to eq(2)
+
+        expected = [@item_4, @item_10]
+        @json['data'].each_with_index do |item, index|
+          expect(item['id']).to eq(expected[index].id.to_s)
+          expect(item['type']).to eq('item')
+
+          attributes = item['attributes']
+          formatted_price = sprintf('%.2f', expected[index].unit_price / 100.0)
+
+          expect(attributes['name']).to eq(expected[index].name)
+          expect(attributes['description']).to eq(expected[index].description)
+          expect(attributes['unit_price']).to eq(formatted_price)
+          expect(attributes['merchant_id']).to eq(expected[index].merchant_id)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/items/find/show_spec.rb
+++ b/spec/requests/api/v1/items/find/show_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'As a visitor', type: :request do
 
     describe 'by its description attribute' do
       before(:each) do
-        get "/api/v1/items/find?updated_at=#{@item_3.updated_at}"
+        get "/api/v1/items/find?description=#{@item_3.description}"
         @json = JSON.parse(response.body)
       end
 
@@ -148,7 +148,7 @@ RSpec.describe 'As a visitor', type: :request do
 
     describe 'by its merchant_id attribute' do
       before(:each) do
-        get "/api/v1/items/find?updated_at=#{@item_7.updated_at}"
+        get "/api/v1/items/find?merchant_id=#{@item_7.merchant_id}"
         @json = JSON.parse(response.body)
       end
 
@@ -169,6 +169,33 @@ RSpec.describe 'As a visitor', type: :request do
         expect(attributes['unit_price']).to eq(sprintf('%.2f',
                                                @item_7.unit_price / 100.0))
         expect(attributes['merchant_id']).to eq(@item_7.merchant_id)
+      end
+    end
+
+    describe 'by its unit_price attribute' do
+      before(:each) do
+        formatted_price = sprintf('%.2f', @item_4.unit_price / 100.0)
+        get "/api/v1/items/find?unit_price=#{formatted_price}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response containing attributes of that item' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.length).to eq(1)
+        expect(@json['data'].length).to eq(3)
+
+        expect(@json['data']['id']).to eq(@item_4.id.to_s)
+        expect(@json['data']['type']).to eq('item')
+
+        attributes = @json['data']['attributes']
+        expect(attributes.length).to eq(5)
+
+        expect(attributes['name']).to eq(@item_4.name)
+        expect(attributes['id']).to eq(@item_4.id)
+        expect(attributes['description']).to eq(@item_4.description)
+        expect(attributes['unit_price']).to eq(sprintf('%.2f',
+                                               @item_4.unit_price / 100.0))
+        expect(attributes['merchant_id']).to eq(@item_4.merchant_id)
       end
     end
   end

--- a/spec/requests/api/v1/items/find/show_spec.rb
+++ b/spec/requests/api/v1/items/find/show_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'As a visitor', type: :request do
+  before(:each) do
+    @merchant = create(:merchant)
+    @item_1 = create(:item, merchant: @merchant)
+    @item_2 = create(:item, merchant: @merchant, name: 'Test Item')
+    @item_3 = create(:item, merchant: @merchant, description: 'Bad Item')
+    @item_4 = create(:item, merchant: @merchant, unit_price: '12345')
+    @item_5 = create(:item, merchant: @merchant, created_at: '1985-10-22')
+    @item_6 = create(:item, merchant: @merchant, updated_at: '2008-09-08')
+    @merchant_2 = create(:merchant)
+    @item_7 = create(:item, merchant: @merchant_2)
+  end
+
+  describe 'when I send a get request to the items find path' do
+    describe 'by its name attribute case-insensitive' do
+      before(:each) do
+        get "/api/v1/items/find?name=#{@item_2.name.downcase}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response containing attributes of that item' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.length).to eq(1)
+        expect(@json['data'].length).to eq(3)
+
+        expect(@json['data']['id']).to eq(@item_2.id.to_s)
+        expect(@json['data']['type']).to eq('item')
+
+        attributes = @json['data']['attributes']
+        expect(attributes.length).to eq(5)
+
+        expect(attributes['name']).to eq(@item_2.name)
+        expect(attributes['id']).to eq(@item_2.id)
+        expect(attributes['description']).to eq(@item_2.description)
+        expect(attributes['unit_price']).to eq(sprintf('%.2f',
+                                               @item_2.unit_price / 100.0))
+        expect(attributes['merchant_id']).to eq(@item_2.merchant_id)
+      end
+    end
+
+    describe 'by its id attribute' do
+      before(:each) do
+        get "/api/v1/items/find?id=#{@item_1.id}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response containing attributes of that item' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.length).to eq(1)
+        expect(@json['data'].length).to eq(3)
+
+        expect(@json['data']['id']).to eq(@item_1.id.to_s)
+        expect(@json['data']['type']).to eq('item')
+
+        attributes = @json['data']['attributes']
+        expect(attributes.length).to eq(5)
+
+        expect(attributes['name']).to eq(@item_1.name)
+        expect(attributes['id']).to eq(@item_1.id)
+        expect(attributes['description']).to eq(@item_1.description)
+        expect(attributes['unit_price']).to eq(sprintf('%.2f',
+                                               @item_1.unit_price / 100.0))
+        expect(attributes['merchant_id']).to eq(@item_1.merchant_id)
+      end
+    end
+
+    describe 'by its created_at attribute' do
+      before(:each) do
+        get "/api/v1/items/find?created_at=#{@item_5.created_at}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response containing attributes of that item' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.length).to eq(1)
+        expect(@json['data'].length).to eq(3)
+
+        expect(@json['data']['id']).to eq(@item_5.id.to_s)
+        expect(@json['data']['type']).to eq('item')
+
+        attributes = @json['data']['attributes']
+        expect(attributes.length).to eq(5)
+
+        expect(attributes['name']).to eq(@item_5.name)
+        expect(attributes['id']).to eq(@item_5.id)
+        expect(attributes['description']).to eq(@item_5.description)
+        expect(attributes['unit_price']).to eq(sprintf('%.2f',
+                                               @item_5.unit_price / 100.0))
+        expect(attributes['merchant_id']).to eq(@item_5.merchant_id)
+      end
+    end
+
+    describe 'by its updated_at attribute' do
+      before(:each) do
+        get "/api/v1/items/find?updated_at=#{@item_6.updated_at}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response containing attributes of that item' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.length).to eq(1)
+        expect(@json['data'].length).to eq(3)
+
+        expect(@json['data']['id']).to eq(@item_6.id.to_s)
+        expect(@json['data']['type']).to eq('item')
+
+        attributes = @json['data']['attributes']
+        expect(attributes.length).to eq(5)
+
+        expect(attributes['name']).to eq(@item_6.name)
+        expect(attributes['id']).to eq(@item_6.id)
+        expect(attributes['description']).to eq(@item_6.description)
+        expect(attributes['unit_price']).to eq(sprintf('%.2f',
+                                               @item_6.unit_price / 100.0))
+        expect(attributes['merchant_id']).to eq(@item_6.merchant_id)
+      end
+    end
+
+    describe 'by its description attribute' do
+      before(:each) do
+        get "/api/v1/items/find?updated_at=#{@item_3.updated_at}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response containing attributes of that item' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.length).to eq(1)
+        expect(@json['data'].length).to eq(3)
+
+        expect(@json['data']['id']).to eq(@item_3.id.to_s)
+        expect(@json['data']['type']).to eq('item')
+
+        attributes = @json['data']['attributes']
+        expect(attributes.length).to eq(5)
+
+        expect(attributes['name']).to eq(@item_3.name)
+        expect(attributes['id']).to eq(@item_3.id)
+        expect(attributes['description']).to eq(@item_3.description)
+        expect(attributes['unit_price']).to eq(sprintf('%.2f',
+                                               @item_3.unit_price / 100.0))
+        expect(attributes['merchant_id']).to eq(@item_3.merchant_id)
+      end
+    end
+
+    describe 'by its merchant_id attribute' do
+      before(:each) do
+        get "/api/v1/items/find?updated_at=#{@item_7.updated_at}"
+        @json = JSON.parse(response.body)
+      end
+
+      it 'I get a JSON:API response containing attributes of that item' do
+        expect(@json.class).to eq(Hash)
+        expect(@json.length).to eq(1)
+        expect(@json['data'].length).to eq(3)
+
+        expect(@json['data']['id']).to eq(@item_7.id.to_s)
+        expect(@json['data']['type']).to eq('item')
+
+        attributes = @json['data']['attributes']
+        expect(attributes.length).to eq(5)
+
+        expect(attributes['name']).to eq(@item_7.name)
+        expect(attributes['id']).to eq(@item_7.id)
+        expect(attributes['description']).to eq(@item_7.description)
+        expect(attributes['unit_price']).to eq(sprintf('%.2f',
+                                               @item_7.unit_price / 100.0))
+        expect(attributes['merchant_id']).to eq(@item_7.merchant_id)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/items/items/index_spec.rb
+++ b/spec/requests/api/v1/items/items/index_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'As a visitor', type: :request do
+  before(:each) do
+    @merchant = create(:merchant)
+    @item_1 = create(:item, merchant: @merchant)
+    @item_2 = create(:item, merchant: @merchant)
+    @item_3 = create(:item, merchant: @merchant)
+
+    @items = [@item_1, @item_2, @item_3]
+  end
+
+  describe 'when I send a request to the items index endpoint' do
+    before(:each) do
+      get "/api/v1/items/"
+      @json = JSON.parse(response.body)
+    end
+
+    it 'I get JSON data for all items' do
+      expect(@json.class).to eq(Hash)
+      expect(@json.keys).to eq(['data'])
+      expect(@json['data'].length).to eq(3)
+
+      items = @json['data']
+      items.each_with_index do |item, index|
+        expect(item['id']).to eq(@items[index].id.to_s)
+        expect(item['type']).to eq('item')
+
+        attributes = item['attributes']
+
+        expect(attributes['name']).to eq(@items[index].name)
+        expect(attributes['description']).to eq(@items[index].description)
+        expect(attributes['unit_price']).to eq(sprintf('%.2f',
+                                              @items[index].unit_price / 100.0))
+        expect(attributes['merchant_id']).to eq(@items[index].merchant_id)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/items/items/show_spec.rb
+++ b/spec/requests/api/v1/items/items/show_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'As a visitor', type: :request do
+  before(:each) do
+    @merchant = create(:merchant)
+    @item_1 = create(:item, merchant: @merchant)
+    @item_2 = create(:item, merchant: @merchant)
+  end
+
+  describe 'when I send a request to the items show endpoint' do
+    before(:each) do
+      get "/api/v1/items/#{@item_1.id}"
+      @json = JSON.parse(response.body)
+    end
+
+    it 'I get JSON data for a single item' do
+      expect(@json.class).to eq(Hash)
+      expect(@json.length).to eq(1)
+      expect(@json['data'].length).to eq(3)
+
+      expect(@json['data']['id']).to eq(@item_1.id.to_s)
+      expect(@json['data']['type']).to eq('item')
+
+      attributes = @json['data']['attributes']
+      expect(attributes.length).to eq(4)
+
+      expect(attributes['name']).to eq(@items[index].name)
+      expect(attributes['description']).to eq(@items[index].description)
+      expect(attributes['unit_price']).to eq(@items[index].unit_price)
+      expect(attributes['merchant_id']).to eq(@items[index].merchant_id)
+    end
+  end
+end

--- a/spec/requests/api/v1/items/items/show_spec.rb
+++ b/spec/requests/api/v1/items/items/show_spec.rb
@@ -22,12 +22,14 @@ RSpec.describe 'As a visitor', type: :request do
       expect(@json['data']['type']).to eq('item')
 
       attributes = @json['data']['attributes']
-      expect(attributes.length).to eq(4)
+      expect(attributes.length).to eq(5)
 
-      expect(attributes['name']).to eq(@items[index].name)
-      expect(attributes['description']).to eq(@items[index].description)
-      expect(attributes['unit_price']).to eq(@items[index].unit_price)
-      expect(attributes['merchant_id']).to eq(@items[index].merchant_id)
+      expect(attributes['name']).to eq(@item_1.name)
+      expect(attributes['id']).to eq(@item_1.id)
+      expect(attributes['description']).to eq(@item_1.description)
+      expect(attributes['unit_price']).to eq(sprintf('%.2f',
+                                             @item_1.unit_price / 100.0))
+      expect(attributes['merchant_id']).to eq(@item_1.merchant_id)
     end
   end
 end

--- a/spec/requests/api/v1/items/most_revenue/index_spec.rb
+++ b/spec/requests/api/v1/items/most_revenue/index_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'As a visitor', type: :request do
 
           expect(attributes['name']).to eq(expected[index].name)
           expect(attributes['description']).to eq(expected[index].description)
-          expect(attributes['unit_price']).to eq(expected[index].unit_price)
+          expect(attributes['unit_price']).to eq(sprintf("%.2f", (expected[index].unit_price / 100.0)))
           expect(attributes['merchant_id']).to eq(expected[index].merchant_id)
         end
       end

--- a/spec/requests/api/v1/items/random/show_spec.rb
+++ b/spec/requests/api/v1/items/random/show_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'As a visitor', type: :request do
+  before(:each) do
+    @merchant = create(:merchant)
+    @item_1 = create(:item, merchant: @merchant)
+    @item_2 = create(:item, merchant: @merchant)
+    @item_3 = create(:item, merchant: @merchant)
+    @names = [@item_1.name, @item_2.name, @item_3.name]
+    @descriptions = [@item_1.description,
+                    @item_2.description,
+                    @item_3.description]
+    @merchant_ids = [@item_1.merchant_id,
+                     @item_2.merchant_id,
+                     @item_3.merchant_id]
+    @ids = [@item_1.id, @item_2.id, @item_3.id]
+    @unit_prices = [@item_1.unit_price_decimal.to_s,
+                    @item_2.unit_price_decimal.to_s,
+                    @item_3.unit_price_decimal.to_s]
+  end
+
+  describe 'when I send a get request to the customers random path' do
+    before(:each) do
+      get '/api/v1/items/random'
+      @json = JSON.parse(response.body)
+    end
+
+    it 'I get a JSON:API response containing attributes of a random customer' do
+      expect(@json.class).to eq(Hash)
+      expect(@json.keys).to eq(['data'])
+      expect(@json['data'].length).to eq(3)
+      expect(@json['data'].class).to eq(Hash)
+
+      expect(@ids).to include(@json['data']['id'].to_i)
+      expect(@json['data']['type']).to eq('item')
+
+      attributes = @json['data']['attributes']
+      expect(attributes.class).to eq(Hash)
+      expect(attributes.length).to eq(5)
+
+      expect(@names).to include(attributes['name'])
+      expect(@descriptions).to include(attributes['description'])
+      expect(@ids).to include(attributes['id'])
+      expect(@unit_prices).to include(attributes['unit_price'])
+      expect(@merchant_ids).to include(attributes['merchant_id'])
+    end
+  end
+end

--- a/spec/requests/api/v1/merchants/items/index_spec.rb
+++ b/spec/requests/api/v1/merchants/items/index_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe 'As a visitor', type: :request do
 
         expect(attributes['name']).to eq(@items[index].name)
         expect(attributes['description']).to eq(@items[index].description)
-        expect(attributes['unit_price']).to eq(@items[index].unit_price)
+        expect(attributes['unit_price']).to eq(sprintf('%.2f',
+                                              @items[index].unit_price / 100.0))
         expect(attributes['merchant_id']).to eq(@items[index].merchant_id)
       end
     end


### PR DESCRIPTION
Resolves #8, resolves #11, resolves #17, resolves #23, resolves #29.

Spec harness `test/endpoints/items_test.rb` file:
```
ItemsApiTest#test_it_can_find_all_instances_by_description = 0.24 s = .
ItemsApiTest#test_it_can_find_all_instances_by_unit_price = 0.02 s = .
ItemsApiTest#test_it_can_find_all_instances_by_id = 0.02 s = .
ItemsApiTest#test_it_can_find_all_instances_by_name = 0.02 s = .
ItemsApiTest#test_it_can_find_all_instances_by_created_at = 0.04 s = .
ItemsApiTest#test_loads_all_items = 0.34 s = .
ItemsApiTest#test_it_can_find_all_instances_by_merchant_id = 0.02 s = .
ItemsApiTest#test_loads_individual_items = 0.02 s = .
ItemsApiTest#test_it_can_find_first_instance_by_id = 0.02 s = .
ItemsApiTest#test_it_can_find_first_instance_by_merchant_id = 0.02 s = .
ItemsApiTest#test_it_can_find_all_instances_by_updated_at = 0.04 s = .
ItemsApiTest#test_it_can_find_first_instance_by_name = 0.01 s = .
ItemsApiTest#test_it_can_find_first_instance_by_updated_at = 0.01 s = .
ItemsApiTest#test_it_can_find_first_instance_by_description = 0.02 s = .
ItemsApiTest#test_it_can_find_first_instance_by_unit_price = 0.01 s = .
ItemsApiTest#test_it_can_find_first_instance_by_created_at = 0.01 s = .

Finished in 0.850981s, 18.8018 runs/s, 3021.2190 assertions/s.
16 runs, 2571 assertions, 0 failures, 0 errors, 0 skips
```

Test results:
```
Finished in 7.19 seconds (files took 3.3 seconds to load)
90 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/turing/3module/projects/rales_engine/coverage. 1925 / 1925 LOC (100.0%) covered.
```